### PR TITLE
Exposify/sequence handler

### DIFF
--- a/app/src/main/kotlin/projects/data_service/Start.kt
+++ b/app/src/main/kotlin/projects/data_service/Start.kt
@@ -4,6 +4,7 @@ import po.exposify.DatabaseManager
 import po.exposify.controls.ConnectionInfo
 import po.exposify.dto.CommonDTO
 import po.exposify.launchService
+import po.exposify.scope.sequence.classes.SequenceHandler
 import po.exposify.scope.service.TableCreateMode
 import po.playground.projects.data_service.data_source.asDataModelDynamically
 import po.playground.projects.data_service.data_source.asDataModelToDelete
@@ -13,39 +14,33 @@ import po.playground.projects.data_service.dto.PartnerDTO
 import po.playground.projects.data_service.dto.PartnerDataModel
 import po.playground.projects.data_service.dto.PartnerEntity
 
+object PartnerUpdate :
+    SequenceHandler<List<PartnerDataModel>>("update_partner", {})
+
+
+fun mockOfRestRequest(){
+    val someInputData = listOf<PartnerDataModel>()
+    PartnerUpdate.execute(someInputData){
+        println(it)
+    }
+}
+
+
 fun startDataService(connectionInfo : ConnectionInfo) {
-
-    val selected =  mutableListOf<CommonDTO<PartnerDataModel, PartnerEntity>>()
-
-    var toDelete : CommonDTO<PartnerDataModel, PartnerEntity>? = null
-    var toModify : CommonDTO<PartnerDataModel, PartnerEntity>? = null
-
-    fun reportResult(result: List<PartnerDataModel>){
-        println(result)
-    }
-
-    fun returnData(data : List<DepartmentDataModel>){
-        println(data)
-    }
 
     val dbManager =  DatabaseManager
     val connection = dbManager.openConnection(connectionInfo){
         service<PartnerDataModel, PartnerEntity>(PartnerDTO, TableCreateMode.CREATE){
-            PartnerDTO.sequence("update_page"){
+            PartnerDTO.sequence(PartnerUpdate){
                 select{
-                    DepartmentDTO.switch{
-                        it.checkout{
-                        callbackOnResult {
-                            returnData(it)
-                        } }
+                    it.checkout{
+
                     }
                 }
             }
         }
     }
-
     PartnerDTO.triggerSequence("update_page")
-
    if(connection){
        println("Connection OK")
 
@@ -56,5 +51,4 @@ fun startDataService(connectionInfo : ConnectionInfo) {
    }else{
        throw Exception("Connection not established")
    }
-
 }

--- a/app/src/main/kotlin/projects/data_service/Start.kt
+++ b/app/src/main/kotlin/projects/data_service/Start.kt
@@ -15,7 +15,7 @@ import po.playground.projects.data_service.dto.PartnerDataModel
 import po.playground.projects.data_service.dto.PartnerEntity
 
 object PartnerUpdate :
-    SequenceHandler<List<PartnerDataModel>>("update_partner", {})
+    SequenceHandler<PartnerDataModel>(PartnerDTO, "update_partner")
 
 
 fun mockOfRestRequest(){
@@ -33,20 +33,17 @@ fun startDataService(connectionInfo : ConnectionInfo) {
         service<PartnerDataModel, PartnerEntity>(PartnerDTO, TableCreateMode.CREATE){
             PartnerDTO.sequence(PartnerUpdate){
                 select{
-                    it.checkout{
-
-                    }
+                    checkout()
                 }
             }
         }
     }
-    PartnerDTO.triggerSequence("update_page")
+    mockOfRestRequest()
    if(connection){
        println("Connection OK")
 
        println("🔄 Processing... Press Enter to exit.")
        readLine()
-
 
    }else{
        throw Exception("Connection not established")

--- a/lib/Exposify/src/main/kotlin/po/exposify/scope/connection/controls/CoroutineEmitter.kt
+++ b/lib/Exposify/src/main/kotlin/po/exposify/scope/connection/controls/CoroutineEmitter.kt
@@ -18,7 +18,7 @@ class CoroutineEmitter(
        pack: SequencePack<DATA, ENTITY>, data : List<DATA>?){
        val listenerScope = CoroutineScope(Dispatchers.IO + CoroutineName(name))
        val job = listenerScope.launch {
-           println("Pre launching Coroutine for pack ${pack.name}")
+           println("Pre launching Coroutine for pack ${pack.sequenceName()}")
            pack.start(data)
            println("Launch")
        }

--- a/lib/Exposify/src/main/kotlin/po/exposify/scope/dto/DTOContext.kt
+++ b/lib/Exposify/src/main/kotlin/po/exposify/scope/dto/DTOContext.kt
@@ -4,7 +4,6 @@ import org.jetbrains.exposed.dao.LongEntity
 import po.exposify.components.eventhandler.models.Event
 import po.exposify.classes.interfaces.DataModel
 import po.exposify.models.CrudResult
-import po.exposify.dto.CommonDTO
 
 /**
  * A context class used to encapsulate and simplify interaction with `DTOFunctions`.
@@ -37,22 +36,24 @@ import po.exposify.dto.CommonDTO
  */
 class DTOContext<DATA, ENTITY>(
     private val  crudResult : CrudResult<DATA, ENTITY>,
+    private val resultCallback: ((Any)-> Unit)? = null,
     )  where DATA : DataModel, ENTITY : LongEntity {
 
-    fun resultAsDataModel(result: ((List<DATA>) -> Unit)? = null): List<DATA>{
-        val dataModels =  crudResult.rootDTOs.map { it.compileDataModel() }
-        if(result != null) result(dataModels)
-        return  dataModels
-    }
 
-    fun getStats(): Event?{
-        crudResult.event?.print()
-        return crudResult.event
-    }
+        init {
+            resultCallback?.let{callbackOnResult(resultCallback)}
+        }
 
-    fun callbackOnResult(callback : (List<DATA>)->Unit ){
-        val dataModels =  crudResult.rootDTOs.map { it.compileDataModel() }
-        callback.invoke(dataModels)
-    }
+        private fun extractData(crud: CrudResult<DATA, ENTITY>): List<DATA>{
+            return  crud.rootDTOs.map { it.compileDataModel() }
+        }
 
+        fun getStats(): Event?{
+            crudResult.event?.print()
+            return crudResult.event
+        }
+
+        fun callbackOnResult(callback : (List<DATA>)->Unit ){
+            callback.invoke(extractData(crudResult))
+        }
 }

--- a/lib/Exposify/src/main/kotlin/po/exposify/scope/dto/DTOContext.kt
+++ b/lib/Exposify/src/main/kotlin/po/exposify/scope/dto/DTOContext.kt
@@ -36,7 +36,7 @@ import po.exposify.models.CrudResult
  */
 class DTOContext<DATA, ENTITY>(
     private val  crudResult : CrudResult<DATA, ENTITY>,
-    private val resultCallback: ((Any)-> Unit)? = null,
+    private val resultCallback: ((List<DATA> )-> Unit)? = null,
     )  where DATA : DataModel, ENTITY : LongEntity {
 
 
@@ -44,7 +44,7 @@ class DTOContext<DATA, ENTITY>(
             resultCallback?.let{callbackOnResult(resultCallback)}
         }
 
-        private fun extractData(crud: CrudResult<DATA, ENTITY>): List<DATA>{
+        fun getData(crud: CrudResult<DATA, ENTITY>): List<DATA>{
             return  crud.rootDTOs.map { it.compileDataModel() }
         }
 
@@ -54,6 +54,6 @@ class DTOContext<DATA, ENTITY>(
         }
 
         fun callbackOnResult(callback : (List<DATA>)->Unit ){
-            callback.invoke(extractData(crudResult))
+            callback.invoke(getData(crudResult))
         }
 }

--- a/lib/Exposify/src/main/kotlin/po/exposify/scope/sequence/SequenceContext.kt
+++ b/lib/Exposify/src/main/kotlin/po/exposify/scope/sequence/SequenceContext.kt
@@ -29,11 +29,20 @@ class SequenceContext<DATA, ENTITY>(
         return result
     }
 
-    fun List<CommonDTO<DATA, ENTITY>>.checkout(
-        block: DTOContext<DATA, ENTITY>.()-> Unit
+//    fun List<CommonDTO<DATA, ENTITY>>.checkout(
+//        block: DTOContext<DATA, ENTITY>.()-> Unit
+//    ) {
+//        DTOContext<DATA, ENTITY>(CrudResult<DATA, ENTITY>(this, null)).block()
+//    }
+
+    fun checkout(
+        block: (DTOContext<DATA, ENTITY>.()-> Unit)?  = null
     ) {
-        @Suppress("UNCHECKED_CAST")
-        DTOContext<DATA, ENTITY>(CrudResult<DATA, ENTITY>(this,null), handler.callback as ((Any) -> Unit)?).block()
+        val newDtoContext = DTOContext<DATA, ENTITY>(
+            CrudResult<DATA, ENTITY>(dtos(), null),
+            handler.getResultCallback() as (List<DATA>) -> Unit
+        )
+        block?.invoke(newDtoContext)
     }
 
     fun <SWITCH_DATA: DataModel, SWITCH_ENTITY : LongEntity> DTOClass<SWITCH_DATA, SWITCH_ENTITY>.switch(

--- a/lib/Exposify/src/main/kotlin/po/exposify/scope/sequence/classes/DefaultSequenceHandler.kt
+++ b/lib/Exposify/src/main/kotlin/po/exposify/scope/sequence/classes/DefaultSequenceHandler.kt
@@ -1,0 +1,15 @@
+package po.exposify.scope.sequence.classes
+
+import po.exposify.classes.interfaces.DataModel
+
+/**
+ * Default implementation of [SequenceHandler] for cases where a sequence is identified by name
+ * instead of a predefined handler object.
+ *
+ * This class is internal because it is meant for framework-level sequence handling
+ * and should not be exposed to external consumers.
+ *
+ * @param T The type of data processed by the sequence handler. Must be a list of [DataModel].
+ * @param name The unique name of the sequence.
+ */
+internal class DefaultSequenceHandler<T: List<DataModel>>(name: String) : SequenceHandler<T>(name)

--- a/lib/Exposify/src/main/kotlin/po/exposify/scope/sequence/classes/DefaultSequenceHandler.kt
+++ b/lib/Exposify/src/main/kotlin/po/exposify/scope/sequence/classes/DefaultSequenceHandler.kt
@@ -1,6 +1,8 @@
 package po.exposify.scope.sequence.classes
 
+import po.exposify.classes.DTOClass
 import po.exposify.classes.interfaces.DataModel
+import po.exposify.dto.CommonDTO
 
 /**
  * Default implementation of [SequenceHandler] for cases where a sequence is identified by name
@@ -12,4 +14,5 @@ import po.exposify.classes.interfaces.DataModel
  * @param T The type of data processed by the sequence handler. Must be a list of [DataModel].
  * @param name The unique name of the sequence.
  */
-internal class DefaultSequenceHandler<T: List<DataModel>>(name: String) : SequenceHandler<T>(name)
+internal class DefaultSequenceHandler<T: DataModel>(dtoModel : DTOClass<T,*> , name: String)
+    : SequenceHandler<T>(dtoModel, name)

--- a/lib/Exposify/src/main/kotlin/po/exposify/scope/sequence/classes/SequeceHandler.kt
+++ b/lib/Exposify/src/main/kotlin/po/exposify/scope/sequence/classes/SequeceHandler.kt
@@ -1,0 +1,88 @@
+package po.exposify.scope.sequence.classes
+
+import po.exposify.classes.interfaces.DataModel
+
+/**
+ * Represents a sealed interface for handling sequence execution and result callbacks.
+ * @param T The type of data processed by the sequence handler.
+ */
+sealed interface SequenceHandlerInterface<T> {
+    /**
+     * The unique name of the sequence handler.
+     */
+    val name: String
+
+    /**
+     * Invokes the result callback function with the provided data.
+     * @param listedData The data to be passed to the result callback.
+     */
+    fun invokeResultCallback(listedData: T)
+}
+
+/**
+ * An abstract class representing a sequence handler, responsible for managing
+ * the execution of sequences and handling their result callbacks.
+ *
+ * @param T The type of data processed by the sequence handler. Must be a list of [DataModel].
+ * @property name The unique name of the sequence handler.
+ * @property resultCallback An optional function that is invoked when a sequence result is available.
+ */
+abstract class SequenceHandler<T : List<DataModel>>(
+    override val name: String,
+    private var resultCallback: ((T) -> Unit)? = null
+) : SequenceHandlerInterface<T> {
+
+    /**
+     * Stores the input data associated with the current sequence execution.
+     */
+    internal var inputData  : T? = null
+
+    /**
+     * Indicates whether input data has been assigned.
+     * @return `true` if input data is available, `false` otherwise.
+     */
+    val hasInputData : Boolean
+        get() { return inputData != null }
+
+    /**
+     * Indicates whether a result callback function is assigned.
+     * @return `true` if a callback is assigned, `false` otherwise.
+     */
+    val hasResultCallback : Boolean
+        get() { return resultCallback != null }
+
+    /**
+     * Executes the stored result callback function with the provided data.
+     * @param listedData The data to pass to the result callback.
+     */
+    internal fun executeCallback(listedData : T){
+        resultCallback?.invoke(listedData)
+    }
+
+    /**
+     * Executes the sequence with the given input data and assigns a result callback function.
+     * @param listedData The input data for the sequence execution.
+     * @param callback The callback function to invoke when the sequence completes.
+     */
+    fun execute(listedData: T, callback:(T)-> Unit){
+        inputData = listedData
+        resultCallback = callback
+    }
+
+    /**
+     * Assigns a result callback function to be executed when the sequence completes.
+     * @param callback The callback function to assign.
+     */
+    fun execute(callback:(T)-> Unit){
+        resultCallback = callback
+    }
+
+    /**
+     * Invokes the result callback function with the provided data.
+     * @param listedData The data to pass to the result callback.
+     */
+    override fun invokeResultCallback(listedData: T) {
+        resultCallback?.invoke(listedData)
+    }
+
+}

--- a/lib/Exposify/src/main/kotlin/po/exposify/scope/sequence/models/SequencePack.kt
+++ b/lib/Exposify/src/main/kotlin/po/exposify/scope/sequence/models/SequencePack.kt
@@ -3,15 +3,21 @@ package po.exposify.scope.sequence.models
 import org.jetbrains.exposed.dao.LongEntity
 import po.exposify.classes.interfaces.DataModel
 import po.exposify.scope.sequence.SequenceContext
+import po.exposify.scope.sequence.classes.SequenceHandler
 
 data class SequencePack<DATA,ENTITY>(
     val context : SequenceContext<DATA,ENTITY>,
     val sequenceFn : suspend  SequenceContext<DATA, ENTITY>.(List<DATA>?) ->Unit,
+    private val handler: SequenceHandler<DATA>,
     ) where  DATA : DataModel, ENTITY : LongEntity {
 
    suspend fun start(withData : List<DATA>?){
        println("Calling start in SequencePack")
        context.sequenceFn(withData)
        println("context.fn() invoked in SequencePack")
+    }
+
+    fun sequenceName(): String{
+        return handler.name
     }
 }

--- a/lib/Exposify/src/main/kotlin/po/exposify/scope/sequence/models/SequencePack.kt
+++ b/lib/Exposify/src/main/kotlin/po/exposify/scope/sequence/models/SequencePack.kt
@@ -5,15 +5,13 @@ import po.exposify.classes.interfaces.DataModel
 import po.exposify.scope.sequence.SequenceContext
 
 data class SequencePack<DATA,ENTITY>(
-    val name : String,
     val context : SequenceContext<DATA,ENTITY>,
-    val fn : suspend  SequenceContext<DATA, ENTITY>.(List<DATA>?) ->Unit,
-    ) where  DATA : DataModel, ENTITY : LongEntity
-{
+    val sequenceFn : suspend  SequenceContext<DATA, ENTITY>.(List<DATA>?) ->Unit,
+    ) where  DATA : DataModel, ENTITY : LongEntity {
 
    suspend fun start(withData : List<DATA>?){
        println("Calling start in SequencePack")
-       context.fn(withData)
+       context.sequenceFn(withData)
        println("context.fn() invoked in SequencePack")
     }
 }

--- a/lib/Exposify/src/main/kotlin/po/exposify/scope/service/ServiceClass.kt
+++ b/lib/Exposify/src/main/kotlin/po/exposify/scope/service/ServiceClass.kt
@@ -55,9 +55,13 @@ class ServiceClass<DATA, ENTITY>(
     private fun launchSequence(name: String, data : List<DATA>? = null){
 
         println("Launch Sequence on ServiceClass with name :${name}")
-        serviceContext?.sequences?.values?.firstOrNull{ it.name ==  name}?.let{pack->
-            println("Found Pack  :${pack.name}")
-            connectionClass.launchSequence<DATA,ENTITY>(pack, data)
+
+        serviceContext?.sequences?.keys?.firstOrNull{ it.name ==  name}?.let{key->
+            val pack = serviceContext?.sequences?.get(key)
+            pack?.let {
+                println("Found Pack  :${key.name}")
+                connectionClass.launchSequence<DATA,ENTITY>(it, data)
+            }
 
         }?:run {
             throw OperationsException("Sequence not found", ExceptionCodes.NOT_INITIALIZED)

--- a/lib/Exposify/src/main/kotlin/po/exposify/scope/service/ServiceClass.kt
+++ b/lib/Exposify/src/main/kotlin/po/exposify/scope/service/ServiceClass.kt
@@ -55,7 +55,7 @@ class ServiceClass<DATA, ENTITY>(
     private fun launchSequence(name: String, data : List<DATA>? = null){
 
         println("Launch Sequence on ServiceClass with name :${name}")
-        serviceContext?.sequences2?.values?.firstOrNull{ it.name ==  name}?.let{pack->
+        serviceContext?.sequences?.values?.firstOrNull{ it.name ==  name}?.let{pack->
             println("Found Pack  :${pack.name}")
             connectionClass.launchSequence<DATA,ENTITY>(pack, data)
 

--- a/lib/Exposify/src/main/kotlin/po/exposify/scope/service/ServiceContext.kt
+++ b/lib/Exposify/src/main/kotlin/po/exposify/scope/service/ServiceContext.kt
@@ -22,7 +22,7 @@ class ServiceContext<DATA,ENTITY>(
     val name : String = "${rootDtoModel.className}|Service"
 
     internal val sequences =
-        mutableMapOf<SequenceHandler<List<DATA>>, SequencePack<DATA, ENTITY>>()
+        mutableMapOf<SequenceHandler<DATA>, SequencePack<DATA, ENTITY>>()
 
     private fun  <T>dbQuery(body : () -> T): T = transaction(dbConnection) {
         body()
@@ -84,19 +84,23 @@ class ServiceContext<DATA,ENTITY>(
         name:String,
         block: suspend SequenceContext<DATA, ENTITY>.(List<DATA>?) -> Unit
     ) {
-        val defaultHandler = DefaultSequenceHandler<List<DATA>>(name){}
+        val defaultHandler = DefaultSequenceHandler<DATA>(rootDtoModel, name)
         val container = SequencePack(
-            SequenceContext<DATA, ENTITY>(dbConnection, rootDtoModel, defaultHandler), block
+            SequenceContext<DATA, ENTITY>(dbConnection, rootDtoModel, defaultHandler),
+            block,
+            defaultHandler
         )
         sequences[defaultHandler] = container
     }
 
     fun DTOClass<DATA, ENTITY>.sequence(
-        handler: SequenceHandler<List<DATA>>,
+        handler: SequenceHandler<DATA>,
         block: suspend SequenceContext<DATA, ENTITY>.(List<DATA>?) -> Unit
     ) {
         val container = SequencePack(
-            SequenceContext<DATA, ENTITY>(dbConnection, rootDtoModel, handler), block
+            SequenceContext<DATA, ENTITY>(dbConnection, rootDtoModel, handler),
+            block,
+            handler
         )
         sequences[handler] = container
     }


### PR DESCRIPTION
SequenceHandler accepts DTOClass<T, *> as a parameter, enabling tighter integration with existing DTOs.
Simplified PartnerUpdate and similar handlers by removing the need for explicit Companion references.
Added the ability to safely trigger sequences within DTOClass with validation for registered sequence names.
Improved the overall readability and maintainability of the sequence execution workflow.
Benefits
Cleaner API: Simplifies the usage of SequenceHandler and DTOClass.

Type Safety: Prevents invalid sequence triggers by enforcing constraints on dtoClass and sequence names.

Extensibility: The new design allows for easier future enhancements without breaking existing functionality.